### PR TITLE
HLK-47 select market to wager

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-REACT_APP_API_URL="http://localhost:3002"
+REACT_APP_API_URL="https://api.horse.link"
 PORT=3000
 GOERLI_URL=https://eth-goerli.g.alchemy.com/v2/nj04KvcteO8qScoGLSYrz0p_tseWlb28
 GOERLI_MNEMONIC=track evoke moment famous camera loud mirror action clip twelve deposit insect

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Offical Dapp for https://horse.link
 
 Market makers can run the the dapp and set their own odds
 
+# The API
+Our own odds can be found at https://api.horse.link/.  These requests are signed by the owner.
+
 ## Goerli
 
 Owner: `0x1Ab4C6d9e25Fc65C917aFBEfB4E963C400Fb9814`  

--- a/src/apis/Api.ts
+++ b/src/apis/Api.ts
@@ -5,7 +5,7 @@ export default class Api {
   private client: AxiosInstance;
   constructor() {
     this.client = axios.create({
-      baseURL: process.env.REACT_APP_API_URL || "http://localhost:3002"
+      baseURL: process.env.REACT_APP_API_URL || "https://api.horse.link"
     });
   }
   public getMeetings = async (): Promise<SignedMeetingsResponse> => {

--- a/src/hooks/useMarkets.ts
+++ b/src/hooks/useMarkets.ts
@@ -1,0 +1,40 @@
+import { useContractRead, useContractReads } from "wagmi";
+import registryContractJson from "../abi/Registry.json";
+import { ethers } from "ethers";
+
+const registryContract = {
+  addressOrName: "0x5Df377d600A40fB6723e4Bf10FD5ee70e93578da",
+  contractInterface: registryContractJson.abi
+};
+
+const useMarketAddresses = () => {
+  const { data: marketCountData } = useContractRead({
+    ...registryContract,
+    functionName: "marketCount"
+  });
+
+  const marketCountStr =
+    marketCountData && ethers.utils.formatUnits(marketCountData, 0);
+  const marketCount = parseInt(marketCountStr ?? "0");
+
+  const { data: marketsData } = useContractReads({
+    contracts: Array.from({ length: marketCount }, (_, i) => {
+      return {
+        ...registryContract,
+        functionName: "markets",
+        args: [i]
+      };
+    })
+  });
+
+  const marketAddresses = marketsData?.filter(v => v) ?? [];
+
+  return { marketAddresses: marketAddresses as unknown as string[] };
+};
+
+const useMarkets = () => {
+  const { marketAddresses } = useMarketAddresses();
+  return { marketAddresses };
+};
+
+export default useMarkets;

--- a/src/hooks/useTokenApproval.ts
+++ b/src/hooks/useTokenApproval.ts
@@ -1,0 +1,90 @@
+import { ethers } from "ethers";
+import { useMemo } from "react";
+import {
+  erc20ABI,
+  useContractRead,
+  useContractWrite,
+  usePrepareContractWrite,
+  useWaitForTransaction
+} from "wagmi";
+
+type useAllowanceArgs = {
+  address: string;
+  owner: string;
+  spender: string;
+  decimals: string;
+};
+const useAllowance = ({
+  address,
+  owner,
+  spender,
+  decimals
+}: useAllowanceArgs) => {
+  const { data: bnAllowance, refetch } = useContractRead({
+    addressOrName: address,
+    contractInterface: erc20ABI,
+    functionName: "allowance",
+    args: [owner, spender]
+  });
+  const allowance = useMemo(() => {
+    if (!bnAllowance) return "0";
+    return Number(ethers.utils.formatUnits(bnAllowance, decimals));
+  }, [bnAllowance]);
+  return { allowance, refetch };
+};
+
+type useApproveContractWriteArgs = {
+  tokenAddress: string;
+  vaultAddress: string;
+  onTxSuccess: () => void;
+};
+
+const useApproveContractWrite = ({
+  tokenAddress,
+  vaultAddress,
+  onTxSuccess
+}: useApproveContractWriteArgs) => {
+  const { config, error: prepareError } = usePrepareContractWrite({
+    addressOrName: tokenAddress,
+    contractInterface: erc20ABI,
+    functionName: "approve",
+    args: [vaultAddress, ethers.constants.MaxUint256]
+  });
+
+  const {
+    data: approveData,
+    write,
+    error: writeError
+  } = useContractWrite(config);
+
+  const { isLoading: isTxLoading } = useWaitForTransaction({
+    hash: approveData?.hash,
+    onSuccess: onTxSuccess
+  });
+
+  return { write, error: prepareError || writeError, isTxLoading };
+};
+
+const useTokenApproval = (
+  tokenAddress: string,
+  ownerAddress: string,
+  vaultAddress: string,
+  tokenDecimal: string
+) => {
+  const { allowance, refetch: refetchAllowance } = useAllowance({
+    address: tokenAddress,
+    owner: ownerAddress,
+    spender: vaultAddress,
+    decimals: tokenDecimal
+  });
+
+  const { write, error, isTxLoading } = useApproveContractWrite({
+    tokenAddress,
+    vaultAddress,
+    onTxSuccess: () => refetchAllowance()
+  });
+
+  return { allowance, write, error, isTxLoading };
+};
+
+export default useTokenApproval;

--- a/src/hooks/useVaults.ts
+++ b/src/hooks/useVaults.ts
@@ -1,0 +1,40 @@
+import { useContractRead, useContractReads } from "wagmi";
+import registryContractJson from "../abi/Registry.json";
+import { ethers } from "ethers";
+
+const registryContract = {
+  addressOrName: "0x5Df377d600A40fB6723e4Bf10FD5ee70e93578da",
+  contractInterface: registryContractJson.abi
+};
+
+const useVaultAddreses = () => {
+  const { data: vaultCountData } = useContractRead({
+    ...registryContract,
+    functionName: "vaultCount"
+  });
+
+  const vaultCountStr =
+    vaultCountData && ethers.utils.formatUnits(vaultCountData, 0);
+  const vaultCount = parseInt(vaultCountStr ?? "0");
+
+  const { data: vaultsData } = useContractReads({
+    contracts: Array.from({ length: vaultCount }, (_, i) => {
+      return {
+        ...registryContract,
+        functionName: "vaults",
+        args: [i]
+      };
+    })
+  });
+
+  const vaultAddresses = vaultsData?.filter(v => v) ?? [];
+
+  return { vaultAddresses: vaultAddresses as unknown as string[] };
+};
+
+const useVaults = () => {
+  const { vaultAddresses } = useVaultAddreses();
+  return { vaultAddresses };
+};
+
+export default useVaults;

--- a/src/pages/Back/Back_Logic.tsx
+++ b/src/pages/Back/Back_Logic.tsx
@@ -10,6 +10,7 @@ import {
 } from "wagmi";
 
 import marketContractJson from "../../abi/Market.json";
+import useMarkets from "../../hooks/useMarkets";
 import { Back } from "../../types";
 import BackView from "./Back_View";
 
@@ -131,11 +132,14 @@ const BackLogic: React.FC = () => {
   const { wagerAmount, setWagerAmount, potentialPayout, contract, txStatus } =
     useBacking(back);
 
+  const { marketAddresses } = useMarkets();
+
   const shouldButtonDisabled = !contract.write || txStatus.isLoading;
 
   return (
     <BackView
       back={back}
+      marketAddresses={marketAddresses}
       wagerAmount={wagerAmount}
       updateWagerAmount={amount => setWagerAmount(amount || 0)}
       potentialPayout={potentialPayout}

--- a/src/pages/Back/Back_View.tsx
+++ b/src/pages/Back/Back_View.tsx
@@ -5,6 +5,7 @@ import { Back } from "../../types";
 
 type Props = {
   back: Back;
+  marketAddresses: string[];
   wagerAmount: number;
   updateWagerAmount: (amount: number) => void;
   potentialPayout: string;
@@ -22,6 +23,7 @@ type Props = {
 
 const BackView: React.FC<Props> = ({
   back,
+  marketAddresses,
   wagerAmount,
   updateWagerAmount,
   potentialPayout,
@@ -38,18 +40,9 @@ const BackView: React.FC<Props> = ({
             <div className="flex flex-col">
               <label>Market</label>
               <select name="markets" id="markets">
-                <option value="0xe9BC1f42bF75C59b245d39483E97C3A70c450c9b">
-                  USDT
-                </option>
-                <option value="0xe9BC1f42bF75C59b245d39483E97C3A70c450c9b1">
-                  DIA
-                </option>
-                <option value="0xe9BC1f42bF75C59b245d39483E97C3A70c450c9b2">
-                  wBTC
-                </option>
-                <option value="0xe9BC1f42bF75C59b245d39483E97C3A70c450c9b3">
-                  wETH
-                </option>
+                {marketAddresses.map(address => (
+                  <MarketOption contractAddress={address} />
+                ))}
               </select>
             </div>
             <div className="flex flex-col">
@@ -103,3 +96,15 @@ const BackView: React.FC<Props> = ({
 };
 
 export default BackView;
+
+type marketOptionProps = {
+  contractAddress: string;
+};
+
+const MarketOption = ({ contractAddress }: marketOptionProps) => {
+  return (
+    <option key={contractAddress} value={contractAddress}>
+      {contractAddress}
+    </option>
+  );
+};

--- a/src/pages/Back/Back_View.tsx
+++ b/src/pages/Back/Back_View.tsx
@@ -16,7 +16,8 @@ type Props = {
   potentialPayout: string;
   shouldButtonDisabled: boolean;
   contract: {
-    write?: () => void;
+    backContractwrite?: () => void;
+    approveContractWrite?: () => void;
     errorMsg?: string;
   };
   txStatus: {
@@ -24,6 +25,7 @@ type Props = {
     isSuccess: boolean;
     hash?: string;
   };
+  isEnoughAllowance: boolean;
 };
 
 const BackView: React.FC<Props> = ({
@@ -36,7 +38,8 @@ const BackView: React.FC<Props> = ({
   potentialPayout,
   shouldButtonDisabled,
   contract,
-  txStatus
+  txStatus,
+  isEnoughAllowance
 }) => {
   return (
     <PageLayout requiresAuth={false}>
@@ -51,6 +54,7 @@ const BackView: React.FC<Props> = ({
                 onChange={e => setSelectedMarket(e.target.value)}
                 name="markets"
                 id="markets"
+                className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
               >
                 {markets.map(address => (
                   <MarketOption key={address} contractAddress={address} />
@@ -85,13 +89,22 @@ const BackView: React.FC<Props> = ({
             <div className="flex justify-end mt-3">
               <RequireWalletButton
                 actionButton={
-                  <button
-                    className="px-5 py-1 hover:bg-gray-100 rounded-md border border-gray-500 shadow-md"
-                    onClick={contract.write}
-                    disabled={shouldButtonDisabled}
-                  >
-                    {txStatus.isLoading ? "Backing..." : "Back"}
-                  </button>
+                  isEnoughAllowance ? (
+                    <button
+                      className="px-5 py-1 hover:bg-gray-100 rounded-md border border-gray-500 shadow-md"
+                      onClick={contract.backContractwrite}
+                      disabled={shouldButtonDisabled}
+                    >
+                      {txStatus.isLoading ? "Backing..." : "Back"}
+                    </button>
+                  ) : (
+                    <button
+                      className="px-5 py-1 hover:bg-gray-100 rounded-md border border-gray-500 shadow-md "
+                      onClick={contract.approveContractWrite}
+                    >
+                      {txStatus.isLoading ? "..." : "Approve"}
+                    </button>
+                  )
                 }
               />
             </div>

--- a/src/pages/Back/Back_View.tsx
+++ b/src/pages/Back/Back_View.tsx
@@ -35,20 +35,23 @@ const BackView: React.FC<Props> = ({
         <div className="w-96 px-10 pt-5 pb-3 rounded-md shadow border-b bg-white border-gray-200 sm:rounded-lg">
           <div className="text-3xl">Target odds {back.odds}</div>
           <form>
-            <select name="markets" id="markets">
-              <option value="0xe9BC1f42bF75C59b245d39483E97C3A70c450c9b">
-                USDT
-              </option>
-              <option value="0xe9BC1f42bF75C59b245d39483E97C3A70c450c9b1">
-                DIA
-              </option>
-              <option value="0xe9BC1f42bF75C59b245d39483E97C3A70c450c9b2">
-                wBTC
-              </option>
-              <option value="0xe9BC1f42bF75C59b245d39483E97C3A70c450c9b3">
-                wETH
-              </option>
-            </select>
+            <div className="flex flex-col">
+              <label>Market</label>
+              <select name="markets" id="markets">
+                <option value="0xe9BC1f42bF75C59b245d39483E97C3A70c450c9b">
+                  USDT
+                </option>
+                <option value="0xe9BC1f42bF75C59b245d39483E97C3A70c450c9b1">
+                  DIA
+                </option>
+                <option value="0xe9BC1f42bF75C59b245d39483E97C3A70c450c9b2">
+                  wBTC
+                </option>
+                <option value="0xe9BC1f42bF75C59b245d39483E97C3A70c450c9b3">
+                  wETH
+                </option>
+              </select>
+            </div>
             <div className="flex flex-col">
               <label>
                 <span>Wager amount</span>

--- a/src/pages/Vaults/Vaults_Logic.tsx
+++ b/src/pages/Vaults/Vaults_Logic.tsx
@@ -1,45 +1,9 @@
-import { useContractInfiniteReads, useContractRead } from "wagmi";
 import VaultsView from "./Vaults_View";
-import registryContractJson from "../../abi/Registry.json";
-import { ethers } from "ethers";
-import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import useVaults from "../../hooks/useVaults";
 
-const registryContract = {
-  addressOrName: "0x5Df377d600A40fB6723e4Bf10FD5ee70e93578da",
-  contractInterface: registryContractJson.abi
-};
 const Vaults: React.FC = () => {
-  const { data: vaultCountData } = useContractRead({
-    ...registryContract,
-    functionName: "vaultCount"
-  });
-
-  const vaultCountStr =
-    vaultCountData && ethers.utils.formatUnits(vaultCountData, 0);
-
-  const { data: vaultDataList, fetchNextPage } = useContractInfiniteReads({
-    cacheKey: "vaultDataList",
-    contracts: (param = 0) => [
-      {
-        ...registryContract,
-        functionName: "vaults",
-        args: [param]
-      }
-    ],
-    getNextPageParam: (_, pages) => pages.length
-  });
-  useEffect(() => {
-    const vaultCount = parseInt(vaultCountStr ?? "0");
-    const dataLength = vaultDataList?.pages.length;
-    if (!fetchNextPage || !dataLength) return;
-    if (dataLength < vaultCount) {
-      fetchNextPage();
-    }
-  }, [vaultCountStr, fetchNextPage, vaultDataList]);
-
-  const vaultAddressList =
-    vaultDataList?.pages.map(arr => arr[0]).filter(v => v) ?? [];
+  const { vaultAddresses } = useVaults();
 
   const navigate = useNavigate();
   const onClickVault = (vaultAddress: string) => {
@@ -47,10 +11,7 @@ const Vaults: React.FC = () => {
   };
 
   return (
-    <VaultsView
-      vaultAddressList={vaultAddressList}
-      onClickVault={onClickVault}
-    />
+    <VaultsView vaultAddressList={vaultAddresses} onClickVault={onClickVault} />
   );
 };
 

--- a/src/pages/Vaults/Vaults_View.tsx
+++ b/src/pages/Vaults/Vaults_View.tsx
@@ -94,9 +94,9 @@ const Row: React.FC<rowProp> = ({ vaultAddress, onClick }) => {
       }
     ]
   });
-  const tokenAddress = vaultData?.[2].toString();
+  const tokenAddress = vaultData?.[2];
   const tokenContract = {
-    addressOrName: tokenAddress || "",
+    addressOrName: tokenAddress?.toString() || "",
     contractInterface: mockTokenContractJson.abi
   };
   const { data: tokenData } = useContractReads({
@@ -113,7 +113,8 @@ const Row: React.FC<rowProp> = ({ vaultAddress, onClick }) => {
         ...tokenContract,
         functionName: "decimals"
       }
-    ]
+    ],
+    enabled: !!tokenAddress
   });
   let rowData = {
     id: "loading...",


### PR DESCRIPTION
#47 

Feat:
- Load market list from `Registry.sol` 
- For each market, read vault address, then show dropdown option using vault's name
- use selected market for `Backing` function
- check user allowance for the token & vault associated with the selected market
- show approve button instead of back if there is not enough allowance

Refactor:
- clean up `useVaults` hooks

# Screenshot
## Dropdown showing market
![image](https://user-images.githubusercontent.com/10498040/194214556-0ad479d3-ad34-4f71-a6b8-a9c313b5b93b.png)
## Not enough allowance, show approve button (will approve int.max amount)
![image](https://user-images.githubusercontent.com/10498040/194214362-fe5053ed-6657-4b81-818a-44b5a917d8b8.png)
## Once approved enough allowance, show back button
![image](https://user-images.githubusercontent.com/10498040/194214241-2c0b2099-3f89-44d3-8228-e37b8c02ad63.png)
