### PR TITLE
fix: remove wagmi eager validate input

### DIFF
--- a/src/hooks/useTokenApproval.ts
+++ b/src/hooks/useTokenApproval.ts
@@ -4,7 +4,6 @@ import {
   erc20ABI,
   useContractRead,
   useContractWrite,
-  usePrepareContractWrite,
   useWaitForTransaction
 } from "wagmi";
 
@@ -44,7 +43,12 @@ const useApproveContractWrite = ({
   vaultAddress,
   onTxSuccess
 }: useApproveContractWriteArgs) => {
-  const { config, error: prepareError } = usePrepareContractWrite({
+  const {
+    data: approveData,
+    write,
+    error
+  } = useContractWrite({
+    mode: "recklesslyUnprepared",
     addressOrName: tokenAddress,
     contractInterface: erc20ABI,
     functionName: "approve",
@@ -52,18 +56,12 @@ const useApproveContractWrite = ({
     enabled: !!tokenAddress && !!vaultAddress
   });
 
-  const {
-    data: approveData,
-    write,
-    error: writeError
-  } = useContractWrite(config);
-
   const { isLoading: isTxLoading } = useWaitForTransaction({
     hash: approveData?.hash,
     onSuccess: onTxSuccess
   });
 
-  return { write, error: prepareError || writeError, isTxLoading };
+  return { write, error, isTxLoading };
 };
 
 const useTokenApproval = (

--- a/src/pages/HorseRace/components/Back/Back_Logic.tsx
+++ b/src/pages/HorseRace/components/Back/Back_Logic.tsx
@@ -6,7 +6,6 @@ import {
   useAccount,
   useContractRead,
   useContractWrite,
-  usePrepareContractWrite,
   useWaitForTransaction
 } from "wagmi";
 
@@ -100,7 +99,12 @@ const useBackContractWrite = ({
   signature,
   enabled
 }: useBackContractWriteArgs) => {
-  const { config, error: prepareError } = usePrepareContractWrite({
+  const {
+    data: contractData,
+    error,
+    write
+  } = useContractWrite({
+    mode: "recklesslyUnprepared",
     addressOrName: marketAddress,
     contractInterface: marketContractJson.abi,
     functionName: "back",
@@ -117,12 +121,6 @@ const useBackContractWrite = ({
     enabled: enabled && !!marketAddress
   });
 
-  const {
-    data: contractData,
-    error: writeError,
-    write
-  } = useContractWrite(config);
-
   const backTxHash = contractData?.hash;
 
   const { isLoading: isTxLoading, isSuccess: isTxSuccess } =
@@ -132,7 +130,7 @@ const useBackContractWrite = ({
 
   return {
     write,
-    error: prepareError || writeError,
+    error,
     isTxLoading,
     isTxSuccess,
     backTxHash

--- a/src/pages/VaultList/components/Vault/Vault_Logic.tsx
+++ b/src/pages/VaultList/components/Vault/Vault_Logic.tsx
@@ -2,12 +2,7 @@ import { useState } from "react";
 import { useParams } from "react-router-dom";
 import VaultView from "./Vault_View";
 import vaultContractJson from "../../../../abi/Vault.json";
-import {
-  useAccount,
-  useContractWrite,
-  usePrepareContractWrite,
-  useWaitForTransaction
-} from "wagmi";
+import { useAccount, useContractWrite, useWaitForTransaction } from "wagmi";
 import { ethers } from "ethers";
 import useTokenData from "../../../../hooks/useTokenData";
 import useTokenApproval from "../../../../hooks/useTokenApproval";
@@ -22,13 +17,13 @@ const useWithdrawContractWrite = ({
   enabled,
   onTxSuccess
 }: useWithdrawContractWriteArgs) => {
-  const { config, error: prepareError } = usePrepareContractWrite({
+  const { data, error, write } = useContractWrite({
+    mode: "recklesslyUnprepared",
     addressOrName: vaultAddress,
     contractInterface: vaultContractJson.abi,
     functionName: "withdraw",
     enabled
   });
-  const { data, error: writeError, write } = useContractWrite(config);
 
   const txHash = data?.hash;
 
@@ -40,7 +35,7 @@ const useWithdrawContractWrite = ({
 
   return {
     write,
-    error: prepareError || writeError,
+    error,
     isTxLoading,
     isTxSuccess,
     txHash
@@ -68,15 +63,15 @@ const useDepositContractWrite = ({
     tokenDecimal
   );
   const receiver = ownerAddress;
-  const { config, error: prepareError } = usePrepareContractWrite({
+
+  const { data, error, write } = useContractWrite({
+    mode: "recklesslyUnprepared",
     addressOrName: vaultAddress,
     contractInterface: vaultContractJson.abi,
     functionName: "deposit",
     args: [assets, receiver],
     enabled
   });
-
-  const { data, error: writeError, write } = useContractWrite(config);
 
   const txHash = data?.hash;
   const { isLoading: isTxLoading, isSuccess: isTxSuccess } =
@@ -87,7 +82,7 @@ const useDepositContractWrite = ({
 
   return {
     write,
-    error: prepareError || writeError,
+    error,
     isTxLoading,
     isTxSuccess,
     txHash


### PR DESCRIPTION
# Context
Unwanted error showing up from contractWrite before hitting the action button
This is due to wagmi default behavior, wagmi will eagerly fetch contract params and gas fee

# Changes
- remove wagmi usePrepareContractWrite
- call writeContract using `unprepare` mode instead (ref: https://wagmi.sh/docs/hooks/useContractWrite#mode)