### PR TITLE
Fix broken USDT faucet

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,5 +6,5 @@ export const getTokenBySymbol = (symbol: string, config?: Config) =>
   );
 
 export const isUsdt = (address: string, config?: Config) =>
-  getTokenBySymbol("USDT", config)?.symbol.toLowerCase() ===
+  getTokenBySymbol("USDT", config)?.address.toLowerCase() ===
   address.toLowerCase();


### PR DESCRIPTION
- Wrong logic: Was comparing address to symbol to determine if USDT. 
- Resulted in sending too large an amount

