### PR TITLE
HL-31 fixing negative time

### DIFF
--- a/src/test/formatting.spec.ts
+++ b/src/test/formatting.spec.ts
@@ -91,22 +91,43 @@ describe("general formatting tests", () => {
   });
 
   it("should get the time difference formatted", () => {
-    const date = moment().add(1, "minute");
-
-    const formattedDifference = utils.formatting.formatTimeToMinutesAndSeconds(
-      date.toString()
+    const dateOne = moment().add(1, "minute");
+    const dateOneFormatted = utils.formatting.formatTimeToMinutesAndSeconds(
+      dateOne.toString()
     );
-
     // account for second elapsing
-    expect(formattedDifference).toEqual("0m 59s");
-  });
-  it("should get the time difference when race is overtime", () => {
-    const date = moment().subtract(1, "minutes");
+    expect(dateOneFormatted).toEqual("0m 59s");
 
-    const formattedDifference = utils.formatting.formatTimeToMinutesAndSeconds(
-      date.toString()
+    const dateTwo = moment().subtract(1, "minute");
+    const dateTwoFormatted = utils.formatting.formatTimeToMinutesAndSeconds(
+      dateTwo.toString()
     );
+    expect(dateTwoFormatted).toEqual("-1m 0s");
 
-    expect(formattedDifference).toEqual("-1m 0s");
+    const dateThree = moment().add(30, "seconds");
+    const dateThreeFormatted = utils.formatting.formatTimeToMinutesAndSeconds(
+      dateThree.toString()
+    );
+    // account for second elapsing
+    expect(dateThreeFormatted).toEqual("0m 29s");
+
+    const dateFour = moment().subtract(30, "seconds");
+    const dateFourFormatted = utils.formatting.formatTimeToMinutesAndSeconds(
+      dateFour.toString()
+    );
+    expect(dateFourFormatted).toEqual("-0m 30s");
+
+    const dateFive = moment().add(1, "minute").add(30, "seconds");
+    const dateFiveFormatted = utils.formatting.formatTimeToMinutesAndSeconds(
+      dateFive.toString()
+    );
+    // account for second elapsing
+    expect(dateFiveFormatted).toEqual("1m 29s");
+
+    const dateSix = moment().subtract(1, "minute").subtract(30, "seconds");
+    const dateSixFormatted = utils.formatting.formatTimeToMinutesAndSeconds(
+      dateSix.toString()
+    );
+    expect(dateSixFormatted).toEqual("-1m 30s");
   });
 });

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -84,20 +84,14 @@ export const formatFirstLetterCapitalised = (string: string) =>
 export const formatTimeToMinutesAndSeconds = (time: string) => {
   // get total seconds difference between given time and now
   const totalSeconds = moment(time).diff(moment(), "seconds");
+  const isNegative = totalSeconds < 0;
+  const prefix = isNegative ? "-" : "";
   // get the minutes difference (loses precision)
-  const minuteDifference =
-    totalSeconds < 0
-      ? Math.ceil(totalSeconds / 60)
-      : Math.floor(totalSeconds / 60);
+  const minuteDifference = isNegative
+    ? Math.ceil(totalSeconds / 60)
+    : Math.floor(totalSeconds / 60);
   // get the remainder for the leftover seconds to regain precision
-  const secondsDifference = totalSeconds % 60;
+  const secondsDifference = Math.abs(totalSeconds % 60);
 
-  const formattedMinutes =
-    totalSeconds < 0 && minuteDifference == 0
-      ? "-" + minuteDifference
-      : minuteDifference;
-  const formattedSeconds =
-    totalSeconds < 0 ? secondsDifference * -1 : secondsDifference;
-
-  return `${formattedMinutes}m ${formattedSeconds}s`;
+  return `${prefix}${Math.abs(minuteDifference)}m ${secondsDifference}s`;
 };


### PR DESCRIPTION
[[Link to ticket](url)](https://dltx.atlassian.net/jira/software/projects/HL/boards/82?selectedIssue=HL-31)

Countdown was 1 minute out once a race went over time. Once race was over time the count would +1 min so it would be -1m:30 instead of -0m:30

![image](https://user-images.githubusercontent.com/48899363/206630042-b4204d9e-1e5f-4cf0-8fd3-b7a278eecf5f.png)

