### PR TITLE
HL-379

### DIFF
--- a/src/hooks/data/useNextToJumpData.ts
+++ b/src/hooks/data/useNextToJumpData.ts
@@ -1,12 +1,12 @@
 import { useMemo } from "react";
 import { NextToJump } from "../../types/meets";
 import useSwr from "../useSwr";
+import constants from "../../constants";
 
 export const useNextToJumpData = () => {
-  const ONE_SECOND = 1000;
   const { data, isLoading, error } = useSwr<NextToJump[]>(
     "/meetings/next",
-    ONE_SECOND * 15
+    constants.time.ONE_SECOND_MS * 15
   );
 
   const nextMeets = useMemo(() => {

--- a/src/hooks/useSwr.ts
+++ b/src/hooks/useSwr.ts
@@ -1,12 +1,13 @@
 import swr from "swr";
 import utils from "../utils";
+import constants from "../constants";
 
 const client = utils.general.getAxiosClient();
 const fetcher = utils.general.getAxiosFetcher(client);
 
-const useSwr = <T>(url: string, interval = 1000) => {
+const useSwr = <T>(url: string, interval = constants.time.ONE_SECOND_MS) => {
   const { data, error } = swr<T>(url, fetcher, {
-    // refresh data every second
+    // refresh data interval
     refreshInterval: interval,
     // even when tab is closed
     refreshWhenHidden: true,


### PR DESCRIPTION
[Link to ticket](https://dltx.atlassian.net/jira/software/projects/HL/boards/82?selectedIssue=HL-379)

- Client no longer hits the next end point every second. Hits it every 15 seconds and caches data for a min. 
![image](https://user-images.githubusercontent.com/48899363/214504133-1c905bd4-d9f4-454e-a555-e87b35c86483.png)
15 seconds in between each API call and new data shows when our endpoint goes external
