### PR TITLE
HL-218

### DIFF
--- a/src/components/Dashboard/DashboardTableRace.tsx
+++ b/src/components/Dashboard/DashboardTableRace.tsx
@@ -51,7 +51,6 @@ export const DashboardTableRace: React.FC<Props> = ({ race, meet }) => {
           "hover:bg-gray-200": race.status === "Normal"
         })}
       >
-        <p>R{race.number}</p>
         {dayjs.utc(race.start).local().format("H:mm")}
         <p>
           {race.status == "Paying"


### PR DESCRIPTION
[Link to ticket](https://dltx.atlassian.net/browse/HL-218)

- As a punter I don't want the race number on each cell so that I can get a clearer view of the starting time

Only effects /dashboard

After:
![Horse_Link](https://user-images.githubusercontent.com/5952255/216233061-6295e0ec-0c57-4973-b124-5d7632eed486.jpg)


Before:
![Horse_Link](https://user-images.githubusercontent.com/5952255/216232971-d8c48823-9aea-4d63-9a29-aa45a3e64534.jpg)
