### PR TITLE
HL-161

### DIFF
--- a/src/hooks/subgraph/useSubgraphBets.ts
+++ b/src/hooks/subgraph/useSubgraphBets.ts
@@ -86,7 +86,8 @@ export const useSubgraphBets = (
     `;
 
     ApolloClient.query<BetResponse>({
-      query
+      query,
+      fetchPolicy: "network-only"
     }).then(({ data: { bets } }) => {
       Promise.all(
         bets.map(async bet => {


### PR DESCRIPTION


[Link to ticket](https://dltx.atlassian.net/jira/software/projects/HL/boards/82?selectedIssue=HL-161)

- fix subgraph data is not updating after settle bet
- set apollo fetch policy for subgraph data to be "network-only" (always call the endpoint while still saving to cache)