### PR TITLE
Gas Limits

### DIFF
--- a/src/hooks/contracts/useMarketContract.ts
+++ b/src/hooks/contracts/useMarketContract.ts
@@ -142,21 +142,27 @@ export const useMarketContract = () => {
     }
 
     const receipt = await (
-      await marketContract.back({
-        nonce: back.nonce,
-        propositionId: utils.formatting.formatBytes16String(
-          back.proposition_id
-        ),
-        marketId: utils.formatting.formatBytes16String(back.market_id),
-        wager,
-        odds: ethers.utils.parseUnits(
-          back.odds.toString(),
-          constants.contracts.MARKET_ODDS_DECIMALS
-        ),
-        close: back.close,
-        end: back.end,
-        signature: back.signature
-      })
+      await marketContract.back(
+        {
+          nonce: back.nonce,
+          propositionId: utils.formatting.formatBytes16String(
+            back.proposition_id
+          ),
+          marketId: utils.formatting.formatBytes16String(back.market_id),
+          wager,
+          odds: ethers.utils.parseUnits(
+            back.odds.toString(),
+            constants.contracts.MARKET_ODDS_DECIMALS
+          ),
+          close: back.close,
+          end: back.end,
+          signature: back.signature
+        },
+        {
+          // transactions take approx 425,000 gas which is ~$100 on testnet
+          gasLimit: 450000
+        }
+      )
     ).wait();
 
     return receipt.transactionHash;


### PR DESCRIPTION
Gas limits

`placeBets` --> `450,000` limit

allowed my _local_ wallet to place the following bets
![image](https://user-images.githubusercontent.com/79682833/226335753-fab4a0b7-6083-49cb-8217-d4ea31520cdc.png)

required transferring lots of ETH over (each back cost approx ~$100 in ETH)