### PR TITLE
Fix invalid .env.development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,4 @@
 VITE_API_URL=http://localhost:3003
-VITE_ALCHEMY_API_KEY=<API_KEY>
 VITE_SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/horse-link/hl-protocol-dev
 VITE_EVENT_TS=0
 VITE_SALT=horselink


### PR DESCRIPTION
Vite uses `.env.development` at runtime. It's not just a blank template like we used for our old projects. Anything in this file overrides the default `.env`. Therefore we should not be committing unusable values into this file. In fact, we should probably consider deleting it from the repo.

This PR just removes the invalid entry from this file.
