### PR TITLE
Show bet result (won or lost), so that I can settle my winning bets. #559

### DIFF
--- a/src/components/Modals/SettleBetModal.tsx
+++ b/src/components/Modals/SettleBetModal.tsx
@@ -171,7 +171,7 @@ export const SettleBetModal: React.FC<Props> = ({
       ) : (
         <div className="p-6">
           <h2 className="font-basement text-[32px] tracking-wider">
-            {utils.formatting.formatFirstLetterCapitalised(bet.status)} Bet #
+            {utils.formatting.formatFirstLetterCapitalised(bet.result)} Bet #
             {bet.index}
           </h2>
 


### PR DESCRIPTION
Closes #559

Logic has been fixed. However, all the resulted bets have "Pending" result so the Modal shows "Pending Bet #1234" instead of "Won Bet #1234" or "Lost Bet #1234"