### PR TITLE
Updated RPC to use env params

### DIFF
--- a/src/hooks/useLocalWallet.ts
+++ b/src/hooks/useLocalWallet.ts
@@ -29,7 +29,7 @@ export const useLocalWallet = (chains: Array<Network>) => {
         const { name } = utils.formatting.formatChain(c);
 
         return new ethers.providers.JsonRpcProvider({
-          url: `https://eth-${name.toLowerCase()}.g.alchemy.com/v2/-Lh1_OMuwKGBKgoU4nk07nz98TYeUZxj`
+          url: `${constants.env.RPC_URL}`
         });
       }),
     [chains]

--- a/src/providers/Wagmi.tsx
+++ b/src/providers/Wagmi.tsx
@@ -18,7 +18,7 @@ const { chains, provider, webSocketProvider } = configureChains(
     jsonRpcProvider({
       rpc: chain => ({
         chainId: chain.id,
-        http: `https://eth-${chain.name.toLowerCase()}.g.alchemy.com/v2/-Lh1_OMuwKGBKgoU4nk07nz98TYeUZxj`
+        http: `${constants.env.RPC_URL}`
       })
     })
   ]


### PR DESCRIPTION
This is expecting the env property VITE_RPC_URL to be set on the box to the full rpc, e.g. 
https://arb-mainnet.g.alchemy.com/v2/SeEaNKLhLNydzFdEdf45twQNDGZgfGVhj4